### PR TITLE
feat(funding): 添加爱发电 + PayPal 捐赠通道与赞助者名单

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,17 @@
+# 赞助渠道配置 — 仓库 Sponsor 按钮的数据源
+#
+# 现状：以下字段先用占位符填写，账号开通后替换为真实用户名/链接即可。
+# - GitHub Sponsors 需要先在 https://github.com/sponsors 申请并通过审核
+# - 爱发电（afdian.com）注册后立刻有个人页面 URL
+#
+# 完整字段说明：https://docs.github.com/sponsors/getting-started-with-github-sponsors/about-github-sponsors
+
+# GitHub Sponsors 用户名（不带 @）。审核通过前先注释掉，避免按钮链接到 404。
+# github: kanfu-panda
+
+# 自定义链接：可填多个。爱发电、Open Collective 的捐赠主页都放在这里。
+custom:
+  # 爱发电（中文用户首选，支付宝/微信收款，原生支持档位订阅）
+  - "https://afdian.com/a/kanfu-panda"
+  # PayPal（国际用户，一次性打赏；提现到国内银行卡）
+  - "https://paypal.me/Leosh980"

--- a/README.md
+++ b/README.md
@@ -265,6 +265,28 @@ User manual: [docs/usage-guide.md](./docs/usage-guide.md) · Release notes: [CHA
 
 ---
 
+## 💖 Support this project
+
+PDLC is built and maintained in spare time. If it saves you hours (or sanity), consider supporting its development.
+
+**Donation channels:**
+
+- 🇨🇳 **[Afdian (爱发电)](https://afdian.com/a/kanfu-panda)** — for users in China; Alipay / WeChat Pay; native support for monthly tiers and one-time tips.
+- 🌍 **[PayPal](https://paypal.me/Leosh980)** — for international users; any amount, one-time.
+
+**Tiers (Afdian — choose monthly or one-time at the same amount):**
+
+| Tier | Afdian | PayPal equivalent | What you get |
+|---|---|---|---|
+| ☕ Tip | ¥10 one-time | $1+ one-time | Thank-you. Not listed. |
+| 🌱 Backer | ¥30/month | $5+ one-time | Your name on [SPONSORS.md](./SPONSORS.md) |
+| 🌳 Sponsor | ¥66/month | $20+ one-time | Name + avatar + link on [SPONSORS.md](./SPONSORS.md) |
+| 🏢 Enterprise | ¥888/month | $100+/month | Logo + link at the top of `README.md` |
+
+If you donate via PayPal, please drop your GitHub handle in [a SPONSORS issue](https://github.com/kanfu-panda/pdlc-skills/issues/new?title=%5BSponsor%5D%20add%20me%20to%20the%20list) so we can add you to the list. The list is updated monthly — see [SPONSORS.md](./SPONSORS.md).
+
+---
+
 ## License
 
 [MIT](./LICENSE) — use it, fork it, ship it.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,3 +247,25 @@ docs/.pdlc-state/<feature-id>.json   ← 每个功能一个状态机文件（如
 - `CODE_OF_CONDUCT.md` — 行为准则
 - `SECURITY.md` — 安全策略
 - `CHANGELOG.md` — 版本变更记录
+
+---
+
+## 💖 支持本项目
+
+PDLC 是业余时间维护的开源项目。如果它给你省下了几个小时（或者一点头发），欢迎支持后续迭代。
+
+**捐赠通道：**
+
+- 🇨🇳 **[爱发电](https://afdian.com/a/kanfu-panda)** — 中国大陆用户首选，支付宝 / 微信支付，原生支持档位订阅与一次性打赏
+- 🌍 **[PayPal](https://paypal.me/Leosh980)** — 国际用户专用，金额自定，一次性打赏
+
+**档位（爱发电按档订阅 / 一次性同价）：**
+
+| 档位 | 爱发电 | PayPal 等值 | 你将获得 |
+|---|---|---|---|
+| ☕ 打赏 | ¥10 一次性 | $1+ 一次性 | 真诚感谢，不进名单 |
+| 🌱 支持者 | ¥30/月 | $5+ 一次性 | 昵称登上 [SPONSORS.md](./SPONSORS.md) |
+| 🌳 长期赞助者 | ¥66/月 | $20+ 一次性 | 昵称 + 头像 + 个人链接登上 [SPONSORS.md](./SPONSORS.md) |
+| 🏢 企业赞助 | ¥888/月 | $100+/月 | 企业 Logo + 链接出现在 `README.md` 顶部 |
+
+通过 PayPal 赞助后，请在 [SPONSORS issue](https://github.com/kanfu-panda/pdlc-skills/issues/new?title=%5BSponsor%5D%20add%20me%20to%20the%20list) 留下你的 GitHub 用户名，方便加入名单。名单按月度同步，见 [SPONSORS.md](./SPONSORS.md)。

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,64 @@
+# 赞助者名单 / Sponsors
+
+> 感谢每一位让 PDLC 持续迭代的支持者。
+> Thank you to everyone who keeps PDLC moving forward.
+>
+> 想加入名单？见 [README.zh-CN.md](./README.zh-CN.md#-支持本项目) / [README.md](./README.md#-support-this-project)。
+
+---
+
+## 🏢 企业赞助 / Enterprise Sponsors
+
+> ¥888/月（爱发电）或 $100+/月（PayPal）及以上 — 在 README 顶部显示企业 Logo + 网站链接。
+> 名额暂未启用，等待第一位企业赞助者。
+
+_暂无 / None yet._
+
+---
+
+## 🌳 长期赞助者 / Sponsors
+
+> ¥66/月（爱发电）或 $20+ 一次性（PayPal）及以上 — 显示昵称、头像、个人/组织链接。
+
+_暂无 / None yet._
+
+<!--
+模板（每位赞助者一行；按月起算时间倒序排列）：
+
+- **昵称** · [@github-handle](https://github.com/handle) · 自 2026-XX
+- **昵称** · 爱发电用户 · 自 2026-XX
+
+-->
+
+---
+
+## 🌱 支持者 / Backers
+
+> ¥30/月（爱发电）或 $5+ 一次性（PayPal）及以上 — 显示昵称。
+
+_暂无 / None yet._
+
+<!--
+模板：
+
+- 昵称 · 自 2026-XX
+- 昵称（GitHub: @handle）· 自 2026-XX
+
+-->
+
+---
+
+## ☕ 一次性打赏 / One-time Tips
+
+一次性打赏不在此名单展示，但每一杯奶茶我们都收到了，谢谢你 ❤️。
+One-time tips aren't listed here, but every coffee was received — thank you ❤️.
+
+---
+
+## 名单更新约定 / Maintenance
+
+- 名单按**月度**人工同步一次，新赞助者最长 30 天内会被加入。
+- 若你赞助后希望**匿名**，请在赞助平台留言注明，或邮件联系作者。
+- 若想取消展示，同样可以邮件联系作者。
+- The list is updated **monthly**. New sponsors appear within 30 days.
+- Want to stay anonymous? Leave a note on the donation platform, or email the author.


### PR DESCRIPTION
## 摘要

- 接入双通道捐赠：**爱发电**（国内主战场，原生订阅）+ **PayPal**（国际兜底，一次性）
- 新增 `.github/FUNDING.yml`，GitHub 会自动在仓库页和 README 顶部渲染「💖 Sponsor」按钮
- 新增 `SPONSORS.md` 三档骨架（Enterprise / Sponsors / Backers），按月度人工同步
- 在 `README.md` / `README.zh-CN.md` 末尾对称添加「Support this project」/「支持本项目」段落

## 档位设计

| 档位 | 爱发电 | PayPal 等值 | 待遇 |
|---|---|---|---|
| ☕ 打赏 | ¥10 一次性 | $1+ 一次性 | 真诚感谢，不进名单 |
| 🌱 支持者 | ¥30/月 | $5+ 一次性 | 昵称登 SPONSORS.md |
| 🌳 长期赞助者 | ¥66/月 | $20+ 一次性 | 昵称 + 头像 + 链接 |
| 🏢 企业赞助 | ¥888/月 | $100+/月 | 企业 Logo 顶部展示 |

## 设计决策

- **跳过 GitHub Sponsors**：Stripe 在中国大陆个人开户极困难，当前体量不值得做美国/香港公司绕道。`FUNDING.yml` 中 `github:` 字段保留注释，未来若开通取消注释即可。
- **PayPal 为一次性**：PayPal.me 不支持原生订阅，国际用户档位以等值打赏方式参与，企业档需手动月转。
- **PayPal 赞助者归因**：PayPal 不会自动同步 GitHub 用户名，README 给了预填 SPONSORS issue 的链接让捐赠者自报家门。
- **维护节奏**：SPONSORS.md 按月度人工同步，避免高频维护成本。

## 已知未尽事项（不阻塞合并）

- [ ] PayPal 当前使用个人账户 `paypal.me/Leosh980`，会公开显示真实姓名。**Business 账户申请中**，通过后会另起小 PR 切换到业务账户的 PayPal.me URL（届时业务名替代真名展示）。
- [ ] 爱发电实名认证 + 档位配置需要在 [afdian.com/a/kanfu-panda](https://afdian.com/a/kanfu-panda) 平台侧完成。

## 测试计划

- [x] `bash tests/frontmatter-check.sh` 通过（32 passed, 0 failed）
- [x] 双语 README 链接对齐核对（爱发电 × 2、PayPal × 2，无残留占位符）
- [x] 公开适配性审计（9.5/10，无 HIGH / MEDIUM 敏感项；Explore agent 多维度扫描通过）
- [x] commit author = `kanfu-panda <slbluefox@gmail.com>`，无 AI co-author 署名
- [ ] 合并后：GitHub 仓库页出现「💖 Sponsor」按钮
- [ ] 合并后：点击按钮验证两个 custom 链接均可达