### PR TITLE
chore(ci): secret-scan 收口到发版触发 + 本地 pre-commit 兜底；ADR 0004 补更正纪要

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# 提交前扫描暂存内容里的密钥。
+#
+# 这道闸原本在 CI（`secret-scan.yml` 的 push/PR 触发），但那样每改一行文档都要跑一遍
+# 全历史扫描，累计烧了 89 次 runner。日常防护挪到这里——本地跑一次不到一秒，且**在密钥
+# 进入历史之前**就拦住；CI 只保留发版那一刻的全历史兜底。
+#
+# 启用（每个克隆做一次）：
+#   git config core.hooksPath .githooks
+#
+# 绕过（仅限确认误报时）：
+#   git commit --no-verify
+set -uo pipefail
+
+# 没有暂存内容就没什么可扫的（比如 `git commit --amend` 空提交）
+git diff --cached --quiet && exit 0
+
+if command -v gitleaks >/dev/null 2>&1; then
+    if ! gitleaks protect --staged --redact --no-banner 2>&1; then
+        echo ""
+        echo "⛔ gitleaks 在暂存内容里发现疑似密钥，已阻止提交。"
+        echo "   确认是误报再用 git commit --no-verify；真泄漏了就轮换密钥，别只删文件。"
+        exit 1
+    fi
+    exit 0
+fi
+
+# gitleaks 不在时**不能当成扫过了**——「跑不了」不等于「没问题」，这是本仓库
+# 三态语义的同一条纪律。降级成正则兜底，并明确说清它比 gitleaks 弱。
+echo "⚠️  未找到 gitleaks，降级为正则兜底扫描（覆盖面弱于 gitleaks）。"
+echo "   装上以获得完整防护：brew install gitleaks"
+
+# 常见密钥前缀 + 连接串。故意写得保守，宁可漏报也别把正常提交拦成噪音——
+# 真正的完整扫描是 gitleaks 的活。
+pattern='(sk-[A-Za-z0-9]{16,}|sk-ant-|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{30,}|gh[pousr]_[A-Za-z0-9]{20,}|xox[bpsar]-[0-9]|-----BEGIN [A-Z ]*PRIVATE KEY-----|(postgres|postgresql|mysql|mongodb(\+srv)?)://[^:@/[:space:]]+:[^@/[:space:]]+@)'
+
+hits="$(git diff --cached -U0 --no-color | grep -E '^\+' | grep -nE "$pattern" || true)"
+if [[ -n "$hits" ]]; then
+    echo ""
+    echo "⛔ 暂存内容里出现疑似密钥，已阻止提交："
+    # 只回显匹配到的模式类别，不回显整行——别把密钥又打印一遍到终端和日志里
+    printf '%s\n' "$hits" | grep -oE "$pattern" | sed 's/^\(.\{8\}\).*/  \1…（已截断）/' | sort -u
+    echo ""
+    echo "   真泄漏了就轮换密钥 + 用 git filter-repo 清历史，别只 git rm。"
+    echo "   确认是误报再用 git commit --no-verify。"
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,10 +1,15 @@
 name: Secret scan
 
+# 只在「发版」这一刻和手动触发时跑。
+#
+# 原先是 `push: branches:[main]` + `pull_request`，累计触发 89 次（PR 55 / push 34）——
+# 每次改一行文档都要跑一遍全历史扫描。日常防护该在本地做（见 .githooks/pre-commit），
+# CI 只留最后一道：**任何东西公开发布之前**，拿 fetch-depth:0 扫一遍完整历史。
 on:
+  workflow_dispatch:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **CI 收口到「只在发布那一刻跑」**：`secret-scan.yml` 原先是 `push: branches:[main]` + `pull_request`，累计触发 89 次（PR 55 / push 34）——改一行文档也要跑一遍全历史扫描。改为 `workflow_dispatch` + `push: tags: v*.*.*`，月预计用量从约 15-20 min 降到约 1 min。发版前那次仍用 `fetch-depth: 0` 扫完整历史，**公开发布前的最后一道兜底保持不变**。
+  - 日常防护落到本地：新增 `.githooks/pre-commit`（`git config core.hooksPath .githooks` 启用一次）。有 `gitleaks` 就用它扫暂存内容；**没有时不静默放行**——降级为正则兜底并明确告知覆盖面更弱（「跑不了」不等于「没问题」，与三态语义同一条纪律）。命中时只回显截断后的模式，不把密钥再打印一遍到终端和日志。
+  - 三条路径均实测：gitleaks 在→拦(exit 1)、gitleaks 不可见→正则兜底仍拦(exit 1)、干净内容→放行(exit 0)。
+
+### Fixed
+
+- **ADR 0004 §5 的诚实边界已过时**，补更正纪要（正文保留作时间点快照）：「本仓库的自动化无法自己调 `codex exec`」实测不成立；`tdd → implement → review` 三步连跑已端到端验证——`design → tdd → impl → review_done` 收敛、退出码 0、独立复跑单测 9/9 绿、发布侧零改动。撞上 provider 限流那次，驱动按设计 fail-stop(4) 且现场零改动。
+
+
 ## [1.6.1] - 2026-08-09
 
 质量报告多了一份**能直接看**的形态，以及三处「本来就该有人盯着」的守卫补位。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,13 +68,21 @@ claude plugin marketplace add /Users/me/projects/pdlc-skills
 claude plugin install pdlc@pdlc-skills
 ```
 
-Tests (run via GitHub Actions on every PR; can also be run manually):
+Tests — **run these locally**; CI only fires on release tags and manual dispatch (see "CI scope" below):
 
 ```bash
 bash tests/frontmatter-check.sh   # validate skills/*/SKILL.md frontmatter
 bash tests/install-smoke.sh       # end-to-end install layout assertions
 shellcheck install.sh tests/*.sh  # bash linting
 ```
+
+Enable the pre-commit secret scan once per clone (`.githooks/pre-commit`, uses `gitleaks` when present and falls back to a pattern scan with a loud warning when it isn't — "can't scan" must never read as "clean"):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+**CI scope**: every workflow is `workflow_dispatch` or release-tag triggered — nothing runs on push-to-main or on PRs. Day-to-day checks belong on your machine; CI is reserved for the moment something gets published (`secret-scan` re-scans the full history with `fetch-depth: 0` before a release goes out). Adding a workflow, or widening an existing trigger, needs the maintainer's explicit go-ahead.
 
 Behavioural evals (`evals/`, added v1.5.3) — verify contracts that only hold when a skill *really runs*:
 

--- a/docs/decisions/0004-codex-loop-run.md
+++ b/docs/decisions/0004-codex-loop-run.md
@@ -96,6 +96,16 @@ docs/usage-guide.md（新增）             ← 「在 Codex 上跑自主收敛�
 ## 5. 局限与诚实边界
 
 - **未做端到端多步真机跑**：作者环境的 Codex 走自定义 provider（`qqqrouter`），其 API key 只在 Codex 运行环境注入、不在普通 subprocess 里——**本仓库的自动化无法自己调 `codex exec`**。因此准入闸的那一步 `implement` 是**用户在真机跑、我读状态机核对**的；完整的 `tdd → implement → review` 三步连跑尚未端到端验证（每个阶段的诚实性由准入闸单点坐实，但多步链式推进的真机连跑留待后续）。驱动的**映射与护栏逻辑**已由 `--dry-run` + mock 状态全覆盖测试。
+
+  > 📌 **更正（2026-08-09，v1.6.1 期间）**：上面这条的两个分句都已不成立，正文保留原样作时间点快照。
+  >
+  > ① **「本仓库的自动化无法自己调 `codex exec`」——实测可以**，从普通 subprocess 直接调通，无需人在 Codex 环境里代跑。
+  >
+  > ② **三步连跑已端到端验证**：起点是一份只有设计文档、无测试无实现的 fixture，跑 `adapters/codex-loop-run.sh`，`design → tdd → impl → review_done` 三步收敛、退出码 0。不采信模型自述，独立复跑单测 **9/9 绿**；实现与测试均为真实产物（处理负数、前导零、参数个数、非整数拒绝）。**发布侧零改动**——无 tag、无 VERSION、无根 CHANGELOG，符合「终态焊死在 `review_done`，发布永远人工」。
+  >
+  > 期间撞上一次 provider 限流：驱动按设计 **fail-stop（退出码 4）且现场零改动**，状态机原封不动。
+  >
+  > 与此同时暴露出 Codex 臂在 `checks` schema 上不稳定（键名 / 类型 / 三态），**与本驱动无关**（驱动只读 `.ok` 与 `.current_stage`），详见 `evals/EVALS.md`「已知限制」第 3 条。
 - **预算护栏靠 `--max-steps`**：外部 Runbook 长跑烧 token，`--max-steps` 是硬上限。更细的美元预算（`--max-budget-usd`）留待需要时加。
 - **vanilla Codex 未覆盖**：见 ADR 0003 实现纪要。
 


### PR DESCRIPTION
两件挂了几天的收尾。

## 1. `secret-scan.yml` 触发条件违规

原先 `push: branches:[main]` + `pull_request`，累计触发 **89 次**（PR 55 / push 34）——改一行文档也要跑一遍全历史扫描。

改为 `workflow_dispatch` + `push: tags: v*.*.*`：

```
月预计 = 1 次发版/月 × ~1 min × 1x(ubuntu) = ~1 min/月（原约 15-20 min/月）
```

发版那次仍用 `fetch-depth: 0` 扫完整历史，**公开发布前的最后一道兜底不变**。

只改触发条件会在发版之间留缺口，所以日常防护落到本地——新增 `.githooks/pre-commit`（本仓库此前**没有任何** pre-commit 钩子）：

- 有 `gitleaks` 就用它扫暂存内容
- **没有时不静默放行**：降级为正则兜底并明说覆盖面更弱。「跑不了」不等于「没问题」，与本仓库三态语义同一条纪律
- 命中时只回显截断后的模式，不把密钥再打印一遍到终端和日志

启用：`git config core.hooksPath .githooks`

## 2. ADR 0004 §5 的诚实边界已过时

正文保留作时间点快照，下方补更正纪要：

- 「本仓库的自动化无法自己调 `codex exec`」——**实测不成立**
- `tdd → implement → review` 三步连跑**已端到端验证**：`design → tdd → impl → review_done`、退出码 0、独立复跑单测 9/9 绿、发布侧零改动（无 tag / 无 VERSION）；撞上 provider 限流那次驱动 fail-stop(4) 且现场零改动

## 顺带

`CLAUDE.md` 一处事实错误：原写 "tests run via GitHub Actions on every PR"，实际 `ci.yml` 一直是 tags-only，PR 上从不跑。

## 验证

- 钩子三条路径实测：gitleaks 在→拦(1)、gitleaks 不可见→正则兜底仍拦(1)、干净→放行(0)
  - 首次测试用了 AWS 文档里的示例 key，gitleaks 有意放行它——**是我的样本不合格**，已换成会命中的
- 三个 workflow 现全部落在白名单内：`pull_request` 0 / `push: branches` 0 / `schedule` 0 / 非 ubuntu runner 0
- 本地 302 断言全通过，`shellcheck` 0 issue（含新钩子）
- 本 PR 的提交本身就跑过这个钩子