### PR TITLE
fix(statusline): 跳过 _relations.json 等索引文件，避免 rebuild 后状态栏变空

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **ADR 0004 §5 的诚实边界已过时**，补更正纪要（正文保留作时间点快照）：「本仓库的自动化无法自己调 `codex exec`」实测不成立；`tdd → implement → review` 三步连跑已端到端验证——`design → tdd → impl → review_done` 收敛、退出码 0、独立复跑单测 9/9 绿、发布侧零改动。撞上 provider 限流那次，驱动按设计 fail-stop(4) 且现场零改动。
+- **状态栏在 `pdlc-relate rebuild`/`set` 之后变空**：`bin/pdlc-statusline.sh` 按 mtime 取最近状态文件时，只排除了 `statusline.json`，没排除 `pdlc-relate` 写出的 `_relations.json`（关系反向索引，不是功能状态文件）。`_relations.json` 写出后 mtime 最新，被当成「最新且非终态」抢占显示，解析出的 `feature_id`/`feature_name`/`current_stage` 全为空，状态栏整行显示成 `● PDLC  · 👤`。现在懒解析循环跳过所有 `_` 前缀文件，jq 解析后再对 `feature_id` 为空的行做一道兜底丢弃。`tests/statusline-check.sh` 新增场景 8 覆盖该回归。
 
 
 ## [1.6.1] - 2026-08-09

--- a/bin/pdlc-statusline.sh
+++ b/bin/pdlc-statusline.sh
@@ -120,12 +120,14 @@ col() { # col <ansi-code> <text>
 }
 
 # ─── 懒解析：按 mtime 取最近 N 个状态文件 ───
-# ls -t 按修改时间新→旧排序，跨平台可用；剔除 statusline.json 后取前 N 个。
+# ls -t 按修改时间新→旧排序，跨平台可用；剔除 statusline.json 及 _ 前缀的索引文件（如
+# pdlc-relate 写出的 _relations.json，不是功能状态文件）后取前 N 个。
 # 用 while-read 而非 mapfile（后者为 bash 4+，macOS 自带 bash 3.2 没有）。
 files=()
 while IFS= read -r f; do
     [[ -z "$f" ]] && continue
     [[ "$(basename "$f")" == "statusline.json" ]] && continue
+    [[ "$(basename "$f")" == _* ]] && continue
     files+=("$f")
     [[ ${#files[@]} -ge "$C_WINDOW" ]] && break
 done < <(ls -t "$state_dir"/*.json 2>/dev/null)
@@ -139,6 +141,9 @@ done < <(ls -t "$state_dir"/*.json 2>/dev/null)
 declare -a rows=()
 while IFS= read -r line; do
     [[ -z "$line" ]] && continue
+    # 第二道保险：feature_id 为空则丢弃这行（非功能状态文件混进来的兜底，
+    # 避免它被当成「最新且非终态」抢占显示权，参见上面 _ 前缀过滤）
+    [[ -z "${line%%"$US"*}" ]] && continue
     rows+=("$line")
 done < <(jq -r '
     def s(x): (x // "") | tostring | gsub("[\r\n\t]"; " ");

--- a/tests/statusline-check.sh
+++ b/tests/statusline-check.sh
@@ -200,6 +200,23 @@ out="$(render; echo "rc=$?")"
 assert_contains "空 state 目录退出码 0" "rc=0" "$out"
 assert_empty "空 state 目录吐空" "${out%rc=0}"
 
+# ─── 场景 8：_relations.json 最新时不抢显示权 ───
+# /pdlc-relate rebuild 会在 state 目录写出 _relations.json（关系反向索引，不是功能状态
+# 文件）。它 mtime 最新也不该被当成"最新且非终态"抢权，否则功能名和阶段全部丢失。
+echo "场景 8：_relations.json 最新时不抢显示权"
+clear_state
+write_state "F20260718-150000.json" "$(cat <<JSON
+{"feature_id":"F20260718-150000","feature_name":"orders","current_stage":"impl",
+ "run_mode":"interactive","next_step":"pdlc-review",
+ "last_phase_result":{"checks":{},"blocked_reason":null,"at":"$(now_iso)"}}
+JSON
+)"
+sleep 1
+write_state "_relations.json" '{"nodes":{},"edges":[],"index":{}}'
+out="$(render)"
+assert_contains "仍显示功能名 orders" "orders" "$out"
+assert_not_contains "不出现空名行" "● PDLC  ·" "$out"
+
 echo ""
 echo "Final: $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## 现象

跑过 `/pdlc-relate rebuild`（或 `set`）的项目，`bin/pdlc-statusline.sh` 状态栏会整行变成：

```
● PDLC  · 👤
```

功能名和阶段全部丢失，直到某个功能状态文件再次被写入。

## 根因

`bin/pdlc-statusline.sh` 第 122-131 行的懒解析循环用 `ls -t "$state_dir"/*.json` 按修改时间取最近 N 个状态文件，循环里只排除了 `statusline.json`（配置文件）：

```bash
files=()
while IFS= read -r f; do
    [[ -z "$f" ]] && continue
    [[ "$(basename "$f")" == "statusline.json" ]] && continue
    files+=("$f")
    [[ ${#files[@]} -ge "$C_WINDOW" ]] && break
done < <(ls -t "$state_dir"/*.json 2>/dev/null)
```

`/pdlc-relate rebuild` / `set` 会在同一个 `docs/.pdlc-state/` 目录写出 `_relations.json`（功能关系的反向索引，不是功能状态文件）。它写出后是目录里 mtime 最新的 JSON，被送进第 143-153 行的 jq 解析。`_relations.json` 里没有 `feature_id` / `feature_name` / `current_stage` 字段，jq 解析后这几列全是空字符串；因为它 mtime 最新，又被判定为"非终态"（`current_stage` 空字符串不以 `_done` 结尾），第 174-179 行的 auto 选择逻辑会把它当成"最近的非终态 feature"抢占显示权，于是渲染出空行。

## 修法

改动集中在 `bin/pdlc-statusline.sh`，最小化，不改其它逻辑：

1. 懒解析循环里新增一行，跳过所有 `_` 前缀的文件（`_relations.json` 等自动生成的索引文件都是这个命名模式）。
2. jq 解析出每行记录后，加一道兜底：`feature_id` 为空的行直接丢弃，不进入候选列表。这样即使将来出现其它非 `_` 前缀但非功能状态的 JSON，也不会被误选。

脚本继续兼容 macOS 自带 bash 3.2（没有用 `mapfile` 或 bash 4 语法）。

## 复现步骤

```bash
T=$(mktemp -d); mkdir -p $T/docs/.pdlc-state
cat > $T/docs/.pdlc-state/F20260901-100000.json <<'JSON'
{"feature_id":"F20260901-100000","feature_name":"search","current_stage":"impl","next_step":"pdlc-review","run_mode":"interactive","history":[],"last_phase_result":{"checks":{},"blocked_reason":null,"at":"2026-09-04T21:40:00+08:00"}}
JSON
sleep 1; echo '{"nodes":{},"edges":[],"index":{}}' > $T/docs/.pdlc-state/_relations.json
printf '{"workspace":{"current_dir":"%s"}}' "$T" | NO_COLOR=1 bash bin/pdlc-statusline.sh; echo
```

修复前输出：`● PDLC  · 👤`
修复后输出：`● PDLC search · PRD·设计·TDD·[实现]·评审·发布 · →评审 · 👤`

## 自检证据

`tests/statusline-check.sh` 新增场景 8，专门覆盖这个回归（一个活跃功能文件 + 之后写入的 `_relations.json`，断言输出包含功能名、不出现空名行）。先临时撤回脚本修复验证测试确实会失败，再恢复修复验证转绿：

```
$ bash tests/statusline-check.sh
...
场景 8：_relations.json 最新时不抢显示权
  ✓ 仍显示功能名 orders
  ✓ 不出现空名行

Final: 29 passed, 0 failed
```

其余测试同步跑过，均通过：

```
$ bash tests/frontmatter-check.sh
Result: 40 passed, 0 failed

$ bash tests/install-smoke.sh
Final: 181 passed, 0 failed

$ shellcheck install.sh tests/*.sh bin/pdlc-statusline.sh
(无输出，退出码 0)
```

## 改动范围

只涉及本 bug：`bin/pdlc-statusline.sh`（修复）、`tests/statusline-check.sh`（新增回归场景）、`CHANGELOG.md`（Unreleased 补一条 Fixed）。没有顺手重构或改动其它内容。