### PR TITLE
fix(loop): 残缺状态不得判成收敛完成；advanced_to 短名改为断言钉住的映射表

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **循环判停会把残缺状态报成「收敛完成」**（外部评审提出，已复现）：`compute_next()` 把缺失的 `next_step` 折成 `"null"` 后映射到 `done`，于是三种输入全部返回退出码 0 + 「✅ 收敛到 review_done」——① 空对象 `{}`；② `current_stage=tdd` 但缺 `next_step`；③ `ok=false`、测试失败、`next_step=null` 且无 `blocked_reason`。这类输入**逃得过「无法解析 → blocked」的兜底**，因为 `{}` 是合法 JSON，解析得了、只是什么都没有。
+  - 根因不在驱动而在契约：`skills/pdlc-loop-next/SKILL.md` 的映射表把 `null → done`，注释写「机械收敛已完成（review 通过）」。查各 skill frontmatter 可知这句是**事实错误**——机械收敛段里没有任何阶段会合法写出 `null`（`pdlc-implement` → `pdlc-review`，`pdlc-review` 与 `pdlc-fix` → `pdlc-ship`），收敛完成的信号是 `next_step=pdlc-ship`，本就单独映射到 `done`。**这条分支没有合法生产者，只在状态残缺时触发。**
+  - 现改为 `null` / 缺失 → `blocked`。展示层早有同一结论（`bin/pdlc-statusline.sh` 的 `is_terminal`：原子 fix 流程 `next` 恒为 `null` 却未完成，误判会显示「✅ done」）——判停层现在与它对齐。
+  - `tests/adapter-codex-loop-run-check.sh` 新增 4 条断言覆盖上述输入，原先那条把 `next=null` 断言成 `done` 的用例一并翻正。ADR 0004 §决策 补更正纪要（正文保留作时间点快照）。
+- **`docs/usage-guide.md` 的状态机范例把 `next_step` 写成短名 `"ship"`**：契约要求的是**下一跳命令名** `"pdlc-ship"`。照抄这份范例会让循环拿到白名单外的 token，直接判 `blocked`。全仓 15 处 `next_step` 字面量里只有这一处写错，已改。
+
+### Changed
+
+- **`advanced_to` 的短名规则改为一张被断言钉住的映射表**：原文写「`advanced_to` = `next_step` 命令去掉 `pdlc-` 前缀」，紧接着又用 ⛔ 块声明「短名不等于命令名去前缀，`pdlc-implement` → `impl`」——**规则与规则的反例挨着写**，而这两段会一起被内联进 Codex skill，模型两边都读得到。实测「去前缀」对 6 个目标里的 `pdlc-implement` 直接给错答案。
+  - 现在 `references/templates/prompts/state-update.md` 用 `<!-- stage-map -->` 锚点给出 6 行显式映射表，并由 `tests/frontmatter-check.sh` **双向**钉死：① 表里每行短名必须等于该 skill 自己 frontmatter 的 `stage:`；② 任何 skill 的非 `null` `next_step` 都必须在表里有行（防止新增阶段时表腐烂）。四种变异（改错短名 / 删一行 / 删整表 / 回退判停规则）均实测变红。
+  - `docs/pdlc-methodology.md` 里重复的同一条「去前缀」规则同步改为指向该表。
+
+
 ## [1.6.2] - 2026-09-05
 
 一次「把噪音关掉」的维护版：CI 收口到只在发版那一刻跑，日常防护落回本地 pre-commit 钩子；顺带修掉状态栏在 `/pdlc-relate rebuild` 之后整行变空的回归。

--- a/adapters/codex-loop-run.sh
+++ b/adapters/codex-loop-run.sh
@@ -48,6 +48,13 @@ fi
 
 # loop-next 映射（复刻 pdlc-loop-next：以 next_step 为主键，blocked_reason/终态优先）。
 # 输出白名单单 token：pdlc-tdd | pdlc-implement | pdlc-review | done | blocked
+#
+# ⛔ next_step 缺失 / 为 null → blocked，**不是** done。机械收敛段里没有任何阶段会
+# 合法写出 null：pdlc-implement → pdlc-review、pdlc-review → pdlc-ship、
+# pdlc-fix → pdlc-ship。收敛完成的信号是 next_step=pdlc-ship（下面单独映射到 done），
+# 不是 null。所以 null 只可能是状态残缺——判 done 等于把「什么都没发生」报成
+# 「机械阶段已完成」，而 `{}` 这种合法但空的 JSON 走不到解析失败的兜底。
+# 展示层早有同一结论：见 bin/pdlc-statusline.sh 的 is_terminal 注释。
 compute_next() {
   local n
   n="$(jq -r '
@@ -55,7 +62,7 @@ compute_next() {
     elif ((.current_stage // "") | endswith("_done")) then "done"
     else (.next_step // "null") as $ns
       | if ($ns == "pdlc-tdd" or $ns == "pdlc-implement" or $ns == "pdlc-review") then $ns
-        elif ($ns == "pdlc-ship" or $ns == "pdlc-deploy" or $ns == "null") then "done"
+        elif ($ns == "pdlc-ship" or $ns == "pdlc-deploy") then "done"
         else "blocked" end
     end
   ' "$STATE" 2>/dev/null)"
@@ -78,7 +85,7 @@ while :; do
       exit 0 ;;
     blocked)
       reason="$(jq -r '.last_phase_result.blocked_reason // empty' "$STATE" 2>/dev/null)"
-      echo "⛔ blocked：${reason:-（状态机无法解析，或 next_step 超出收敛段——需人工）}"
+      echo "⛔ blocked：${reason:-（状态机无法解析、结构残缺/缺 next_step，或 next_step 超出收敛段——需人工）}"
       exit 2 ;;
     pdlc-tdd|pdlc-implement|pdlc-review) ;;
     *)

--- a/docs/decisions/0004-codex-loop-run.md
+++ b/docs/decisions/0004-codex-loop-run.md
@@ -67,6 +67,19 @@
    - `blocked_reason` 非空 → `blocked`
    - `current_stage` 以 `_done` 结尾 → `done`
    - 否则以 `next_step` 为主键：`pdlc-tdd/implement/review` → 该阶段；`pdlc-ship/deploy/null` → `done`（发布留人）；`pdlc-prd/design` 或其它 → `blocked`
+
+  > 📌 **更正（2026-09-07）**：上面 `null → done` 这一段已不成立，正文保留原样作时间点快照。
+  >
+  > 机械收敛段里**没有任何阶段会合法写出 `next_step: null`**——`pdlc-implement` 写
+  > `pdlc-review`，`pdlc-review` 与 `pdlc-fix` 都写 `pdlc-ship`。收敛完成的信号是
+  > `next_step=pdlc-ship`（本就单独映射到 `done`），不是 `null`。所以 `null` 只可能是
+  > **状态残缺**，判 `done` 等于把「什么都没发生」报成「机械阶段已完成」。
+  >
+  > 实测三份输入在改前均返回退出码 0 + 「✅ 收敛到 review_done」：`{}`、
+  > `current_stage=tdd` 但缺 `next_step`、`ok=false` 且 `next_step=null` 且无
+  > `blocked_reason`。它们**逃得过「无法解析 → blocked」的兜底**（`{}` 是合法 JSON）。
+  > 现映射改为 `null` / 缺失 → `blocked`，`tests/adapter-codex-loop-run-check.sh`
+  > 新增 4 条断言覆盖。
 2. `done` → 成功停机（交人工 `/pdlc-ship`）；`blocked` → 停机交还人类。
 3. 否则跑 `codex exec -C <项目> -s workspace-write "按 pdlc <阶段> <id> --autonomous"`。
 4. 读回状态机判定护栏（对齐 Claude 版 loop-run）：

--- a/docs/pdlc-methodology.md
+++ b/docs/pdlc-methodology.md
@@ -113,7 +113,7 @@ Product Development Life Cycle——把一个功能的开发切成有序、有�
    阶段语义不同则用对应键（如 TDD 段用 `{ "red_verified": true }` 表示红灯已验证）。
 2. **`self_audit` 单列**：只放自检未通过数，**仅供参考，不作判停依据**。
 3. **`ok` 定义**：本阶段全部 `checks` 通过且未命中 `blocked_reason` → `true`；否则 `false`。
-4. **命名空间**：`advanced_to` = 下一阶段短名（= `next_step` 去掉 `pdlc-` 前缀）；到终态或无后续时 `advanced_to=null`。
+4. **命名空间**：`advanced_to` = 下一阶段短名；到终态或无后续时 `advanced_to=null`。短名**不是**命令名去掉 `pdlc-` 前缀（`pdlc-implement` → `impl`），唯一真源是 `references/templates/prompts/state-update.md` 里的映射表，该表由 `tests/frontmatter-check.sh` 与各 skill 的 `stage:` frontmatter 双向对齐。
 5. **推进一致**：`ok=true` 时本阶段必须真的推进了 `current_stage`（呼应 IRON LAW #6）；
    `ok=false`（含 blocked）时 `current_stage` 不变、`advanced_to=null`、`blocked_reason` 写明原因。
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -274,7 +274,7 @@ Claude Code **集成最全**（本手册前面全部内容）。但 PDLC 的方�
       "self_audit": { "passed": 8, "failed": 0, "manual": 0 }
     }
   ],
-  "next_step": "ship",
+  "next_step": "pdlc-ship",
   "terminal_state": null
 }
 ```

--- a/references/templates/prompts/state-update.md
+++ b/references/templates/prompts/state-update.md
@@ -75,9 +75,27 @@
    > ⚠️ **没有检查命令可跑的阶段（如 requirements/design 只产文档，或项目无 `test-commands.yml`）→ `checks: {}` 留空。绝不因为「本阶段成功」就把 `tests_pass`/`lint_clean` 等填 `true`——那是虚报，会污染跨工具共用的状态机、误导自主循环判停。** 上面 schema 示例里 `checks` 之所以是空的，正是这个原因——**空是"没跑"的意思，不是键名的示范**。
 2. **`self_audit` 单列**：只放自检未通过数，**仅供参考，不作循环判停依据**。
 3. **`ok` 的定义**：本阶段全部 `checks` 通过且未命中 `blocked_reason` → `true`；否则 `false`。
-4. **命名空间**：`advanced_to` = **下一阶段的短名**（= `next_step` 命令去掉 `pdlc-` 前缀，如 `next_step=pdlc-review` → `advanced_to=review`），**不是命令名、也不是本阶段的 `current_stage`**。三者关系：`stage`=本阶段短名、`current_stage`=本阶段完成后的当前短名、`advanced_to`=下一阶段短名、`next_step`=下一跳命令名。
-   > ⛔ **短名不等于命令名去前缀**，各阶段的短名以本 skill 正文写明的为准。最容易踩的是
-   > `pdlc-implement` → 短名是 **`impl`**，不是 `implement`。写错的后果与键名写错同类：
-   > 消费方按契约名匹配，认不出就当没这个阶段。
+4. **命名空间**：`advanced_to` = **下一阶段的短名**，**不是命令名、也不是本阶段的 `current_stage`**。三者关系：`stage`=本阶段短名、`current_stage`=本阶段完成后的当前短名、`advanced_to`=下一阶段短名、`next_step`=下一跳命令名。
+
+   ⛔ **短名不是「命令名去掉 `pdlc-` 前缀」**——`pdlc-implement` 的短名是 **`impl`**，不是 `implement`。别推导，查下表：
+
+<!-- stage-map:start -->
+   | `next_step`（下一跳命令名） | `advanced_to`（下一阶段短名） |
+   |---|---|
+   | `pdlc-tdd` | `tdd` |
+   | `pdlc-implement` | `impl` |
+   | `pdlc-review` | `review` |
+   | `pdlc-design` | `design` |
+   | `pdlc-ship` | `ship` |
+   | `pdlc-deploy` | `deploy` |
+<!-- stage-map:end -->
+
+   `next_step` 为 `null`（终态或无后续）时 `advanced_to` 也是 `null`。
+
+   > 📌 **本表是唯一真源，且是被断言钉住的**：每行的短名必须等于该 skill 自己 frontmatter
+   > 里声明的 `stage:`，且任何 skill 的非 `null` `next_step` 都必须在表里有行——两个方向
+   > 都由 `tests/frontmatter-check.sh` 检查，所以表不会和实现各自漂移。
+   >
+   > 写错短名的后果与键名写错同类：消费方按契约名匹配，认不出就当没这个阶段。
 5. **推进一致**：`ok=true` 时本阶段必须真的推进了 `current_stage`（与第 6 条 IRON LAW 呼应）；到达终态或无后续时 `advanced_to=null`。`ok=false`（含 blocked）时 `current_stage` 不变、`advanced_to=null`、`blocked_reason` 写明原因。
 6. **`run_mode`**：镜像本次调用是否带 `--autonomous`（见 `noninteractive.md`）。

--- a/skills/pdlc-loop-next/SKILL.md
+++ b/skills/pdlc-loop-next/SKILL.md
@@ -44,9 +44,20 @@ pdlc-tdd | pdlc-implement | pdlc-review | done | blocked
    | `pdlc-tdd` | `pdlc-tdd` | |
    | `pdlc-implement` | `pdlc-implement` | |
    | `pdlc-review` | `pdlc-review` | |
-   | `pdlc-ship` / `pdlc-deploy` / `null` | `done` | 机械收敛已完成（review 通过），发布留人 |
+   | `pdlc-ship` / `pdlc-deploy` | `done` | 机械收敛已完成（review 通过），发布留人 |
+   | `null` / 缺失 | `blocked` | **状态残缺**——收敛段无阶段会合法写出 null，见下 |
    | `pdlc-prd` / `pdlc-design` | `blocked` | 尚在 tdd 之前，需人工（超出循环范围） |
    | 其它 | `blocked` | |
+
+   > ⛔ **`null` 判 `blocked` 而不是 `done`**：机械收敛段里没有任何阶段会合法写出
+   > `next_step: null`——`pdlc-implement` 写 `pdlc-review`、`pdlc-review` 与 `pdlc-fix`
+   > 都写 `pdlc-ship`。**收敛完成的信号是 `next_step=pdlc-ship`**（上表已单独映射到
+   > `done`），不是 `null`。所以 `null` 只可能是状态残缺，判 `done` 等于把「什么都
+   > 没发生」报成「机械阶段已完成」——上层会以为可以进发布评估了。
+   >
+   > 注意这类输入**逃得过「无法解析 → blocked」的兜底**：`{}` 是合法 JSON，
+   > 解析得了、只是什么都没有。展示层早有同一结论（`bin/pdlc-statusline.sh` 的
+   > `is_terminal`：原子 fix 流程 `next` 恒为 `null` 却未完成，误判会显示「✅ done」）。
 
 6. 不写文件、不产任何 artifact。
 

--- a/tests/adapter-codex-loop-run-check.sh
+++ b/tests/adapter-codex-loop-run-check.sh
@@ -72,10 +72,26 @@ write_state ship-next     review pdlc-ship      null
 assert_run "next=pdlc-ship → done"                   ship-next     0 "review_done"
 write_state deploy-next   deploy pdlc-deploy    null
 assert_run "next=pdlc-deploy → done"                 deploy-next   0 "review_done"
-write_state null-next     review null           null
-assert_run "next=null → done"                        null-next     0 "review_done"
 write_state terminal      feature_done null      null
 assert_run "current_stage=feature_done → done"       terminal      0 "review_done"
+
+echo ""
+echo "Test: 结构残缺 → blocked（绝不判成收敛完成）"
+# 机械收敛段里没有任何阶段会合法写出 next_step=null：
+#   pdlc-implement → pdlc-review、pdlc-review → pdlc-ship、pdlc-fix → pdlc-ship。
+# 所以 next_step 缺失/为 null 只可能是状态残缺，判 done 等于把「什么都没发生」报成
+# 「机械阶段已完成」。展示层早有同样结论（bin/pdlc-statusline.sh 的 is_terminal 注释）。
+printf '%s' '{}' > "$MK/docs/.pdlc-state/empty-obj.json"
+assert_run "空对象 {} → blocked"                     empty-obj     2 "blocked"
+printf '%s' '{"feature_id":"no-next","current_stage":"tdd"}' > "$MK/docs/.pdlc-state/no-next.json"
+assert_run "current_stage=tdd 但缺 next_step → blocked" no-next     2 "blocked"
+cat > "$MK/docs/.pdlc-state/failed-null.json" <<'JSON'
+{ "feature_id": "failed-null", "current_stage": "impl", "next_step": null,
+  "last_phase_result": { "ok": false, "checks": { "tests_pass": false }, "blocked_reason": null } }
+JSON
+assert_run "ok=false/测试失败/next=null/无阻塞原因 → blocked" failed-null 2 "blocked"
+write_state null-next     review null           null
+assert_run "next=null（结构完整但无下一跳）→ blocked"  null-next     2 "blocked"
 
 echo ""
 echo "Test: 超出收敛段 / blocked → blocked（退出 2）"

--- a/tests/frontmatter-check.sh
+++ b/tests/frontmatter-check.sh
@@ -168,6 +168,58 @@ for f in skills/*/SKILL.md; do
     fi
 done
 
+
+# ─── 检查 7：阶段短名映射表必须与各 skill 的 stage frontmatter 一致 ───
+# state-update.md 原先写「advanced_to = next_step 命令去掉 pdlc- 前缀」，这条规则对
+# pdlc-implement 直接给错答案（短名是 impl 不是 implement），文档只能在紧邻处用 ⛔ 打
+# 补丁——规则与规则的反例挨着写，模型两边都读得到。改为一张显式映射表后，由本断言
+# 双向钉死，防止表和实现各自漂移：
+#   ① 表里每一行的短名，必须等于该 skill 自己 frontmatter 声明的 stage
+#   ② 任何 skill 的非 null next_step，都必须在表里有一行（防止新增阶段时表腐烂）
+echo ""
+echo "Check: 阶段短名映射表（advanced_to）"
+MAP_FILE="references/templates/prompts/state-update.md"
+
+stage_map() { # → 每行「<命令名> <短名>」
+    awk '/<!-- stage-map:start -->/{f=1;next} /<!-- stage-map:end -->/{f=0} f' "$MAP_FILE" 2>/dev/null \
+      | awk -F'|' 'NF>=3 { c=$2; s=$3; gsub(/[ `]/,"",c); gsub(/[ `]/,"",s);
+                           if (c ~ /^pdlc-/) print c, s }'
+}
+
+map_n=0
+while read -r cmd short; do
+    [[ -z "$cmd" ]] && continue
+    map_n=$((map_n + 1))
+    if [[ ! -f "skills/$cmd/SKILL.md" ]]; then
+        echo "  ✗ 映射表引用了不存在的 skill: $cmd"; fail=$((fail + 1)); continue
+    fi
+    declared="$(awk -F': *' '/^stage:/{print $2; exit}' "skills/$cmd/SKILL.md" | tr -d '\r')"
+    if [[ "$declared" != "$short" ]]; then
+        echo "  ✗ $cmd: 映射表写 '$short'，但该 skill frontmatter 声明 stage: '$declared'"
+        fail=$((fail + 1))
+    else
+        echo "  ✓ ${cmd} → ${short}（与 frontmatter 一致）"; pass=$((pass + 1))
+    fi
+done < <(stage_map)
+
+if [[ "$map_n" -eq 0 ]]; then
+    echo "  ✗ 未在 $MAP_FILE 找到 stage-map 表（缺 <!-- stage-map:start --> 锚点？）"
+    fail=$((fail + 1))
+fi
+
+# ② 反向：每个非 null 的 next_step 都必须在表里
+missing_rows=""
+for f in skills/*/SKILL.md; do
+    ns="$(awk -F': *' '/^next_step:/{print $2; exit}' "$f" | tr -d '\r')"
+    [[ -z "$ns" || "$ns" == "null" ]] && continue
+    stage_map | grep -qE "^$ns " || missing_rows="${missing_rows}${ns} "
+done
+if [[ -z "$missing_rows" ]]; then
+    echo "  ✓ 每个非 null 的 next_step 在映射表里都有对应行"; pass=$((pass + 1))
+else
+    echo "  ✗ 这些 next_step 在映射表里没有行（表已腐烂）: $missing_rows"; fail=$((fail + 1))
+fi
+
 echo ""
 echo "Result: $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
落实外部评审的第 1、2 条。两条我都先自己复现了，**没有直接采信**；第 1 条的根因比评审指的位置深一层。

## 1. 循环判停把残缺状态报成「收敛完成」

三份输入原样跑，全中：

```
① 空对象 {}                          rc=0  ✅ 收敛到 review_done
② current_stage=tdd，缺 next_step     rc=0  ✅ 收敛到 review_done
③ ok=false/测试失败/next=null/无阻塞原因  rc=0  ✅ 收敛到 review_done
```

对照组 `完全不是 JSON → blocked(rc=2)` 是对的——**兜底只挡住了「解析不了」，没挡住「解析得了但结构是空的」**。`{}` 是合法 JSON。

### 根因不在驱动，在契约

评审指向 `adapters/codex-loop-run.sh#L51`，那是症状。根因是 `skills/pdlc-loop-next/SKILL.md` 的映射表把 `null → done`，注释写「机械收敛已完成（review 通过）」，adapter 只是忠实复刻。

查各 skill frontmatter 可知**这句注释是事实错误**：

```
pdlc-implement  next_step=pdlc-review
pdlc-review     next_step=pdlc-ship
pdlc-fix        next_step=pdlc-ship
```

机械收敛段里**没有任何阶段会合法写出 `next_step: null`**。收敛完成的信号是 `next_step=pdlc-ship`（本就单独映射到 `done`）。写 `null` 的 28 个 skill 全是 Layer 3 工具，本就在循环范围外。

**所以这条分支没有合法生产者，只在状态残缺时触发。** 修法因此比评审建议的「入口结构校验」更简单也更彻底：**删掉它，`null` / 缺失 → `blocked`**。

仓库自证：`bin/pdlc-statusline.sh` 的 `is_terminal` 注释早写着「不把 `next_step==null` 当终态：原子 fix 流程 next 恒为 null 却未完成，误判会显示『✅ done』」。**展示层早就规避了这个坑，判停层没同步**——这次对齐。

## 2. `advanced_to` 短名规则自相矛盾

```
L78  advanced_to = 下一阶段短名（= next_step 去掉 pdlc- 前缀）
L79  ⛔ 短名不等于命令名去前缀…pdlc-implement → 短名是 impl
```

规则与规则的反例**挨着写**，而这两段会一起被内联进 Codex skill，模型两边都读得到。实测「去前缀」对 6 个目标里的 `pdlc-implement` 直接给错答案。

改为 `<!-- stage-map -->` 锚点下的 6 行显式映射表，并由 `tests/frontmatter-check.sh` **双向**钉死：

1. 表里每行短名必须等于该 skill 自己 frontmatter 的 `stage:`
2. 任何 skill 的非 `null` `next_step` 都必须在表里有行（防止新增阶段时表腐烂）

数据不用新造——权威映射本来就在各 skill 的 frontmatter 里，这次只是显式化 + 加断言。

## 顺带修掉的相邻问题

`docs/usage-guide.md:277` 的状态机范例把 `next_step` 写成短名 `"ship"`，契约要求命令名 `"pdlc-ship"`。**照抄这份范例会让循环拿到白名单外的 token，直接判 `blocked`。** 全仓 15 处 `next_step` 字面量里只有这一处错。

`docs/pdlc-methodology.md:116` 里重复的同一条「去前缀」规则同步改为指向映射表。ADR 0004 按仓库惯例补更正纪要，正文保留作时间点快照。

## 自检证据

**TDD**：两组断言都先写红再改代码。

```
第 1 项写完测试（未改代码）: 17 passed, 4 failed
第 2 项写完测试（表未建）:   40 passed, 2 failed
```

**变异测试**，四种均实测变红：

| 变异 | 结果 |
|---|---|
| 把 `null → done` 放回去 | 4 条红 |
| 表里 `impl` 写成 `implement`（旧规则会推出的答案） | ✗ 映射表写 'implement'，frontmatter 声明 'impl' |
| 删掉一行 | ✗ 表已腐烂: pdlc-review |
| 删掉整张表 | ✗ 未找到 stage-map 锚点 + 10 个 next_step 无行 |

**全量 314 断言全绿**（原 304，+10）：

```
adapter-codex-check            32 passed, 0 failed
adapter-codex-loop-run-check   21 passed, 0 failed   ← 原 18
evals-runner-check              4 passed, 0 failed
frontmatter-check              47 passed, 0 failed   ← 原 40
install-smoke                 181 passed, 0 failed
statusline-check               29 passed, 0 failed   （另用 macOS 自带 bash 3.2 复跑）

shellcheck （含 adapters/*.sh）   rc=0
evals --check                    fixture 全通过
```

**Codex 投影核对**：映射表已正确内联进投影后的 skill，loop-next 的新规则也在，无残留 `@include`。

## 未包含

评审的第 3、4 条（eval 把协议错统计成抖动、发布闸门的报告新鲜度绑定）涉及 eval 语义与发布闸门行为变更，按讨论结果留待单独议。
